### PR TITLE
add a view to handle SwaggerUI oauth redirects

### DIFF
--- a/drf_spectacular_sidecar/views.py
+++ b/drf_spectacular_sidecar/views.py
@@ -1,0 +1,7 @@
+from django.template.context_processors import static
+from django.views.generic import RedirectView
+
+
+class SwaggerOauthRedirectView(RedirectView):
+    def get_redirect_url(self, *args, **kwargs):
+        return static("drf_spectacular_sidecar/swagger-ui-dist/oauth2-redirect.html") + f"?{self.request.GET.urlencode()}"

--- a/drf_spectacular_sidecar/views.py
+++ b/drf_spectacular_sidecar/views.py
@@ -1,4 +1,4 @@
-from django.template.context_processors import static
+from django.templatetags.static import static
 from django.views.generic import RedirectView
 
 


### PR DESCRIPTION
I tried to use the bundled SwaggerUI with OAuth authentication using the `SWAGGER_UI_OAUTH2_CONFIG` setting. The UI successfully configured itself and authentication is performed, however OAuth requires a callback back to the application (in this case back to SwaggerUI) but there was no view included in *drf-spectacular* to serve that callback.
With this PR, I have added such a view so that OAuth authentication can be used.

This PR is placed in the *sidecar* package because the way that SwaggerUI handles OAuth callbacks is that it expects the `oauth2-redirect.html` file to handle the callback, and this file is only available in the sidecar package.

This file can be served using an *urlpatterns* like the following:
```python
urlpatterns = [
    path("schema/", SpectacularAPIView.as_view(), name="openapi-schema"),
    path("schema/swagger-ui/", SpectacularSwaggerView.as_view(url_name="openapi-schema"), name="swagger-ui"),
    path("schema/swagger-ui/oauth2-redirect.html", SwaggerRedirectView.as_view(), name="swagger-ui-oauth-redirect"),
] 
```